### PR TITLE
Unify parse and render between python and rust

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,129 +1,17 @@
 pub mod fov;
+pub mod parse_and_render;
 pub mod parsing_utils;
 pub mod rendering;
 pub mod types;
 
-use crate::parsing_utils::read_stars;
-use crate::rendering::render_stars;
-use crate::types::EquatorialCoords;
+use crate::types::StarCatalogArgs;
+use crate::parse_and_render::parse_and_render;
 
-use clap::Parser;
 use pyo3::prelude::*;
-use std::time::Instant;
-
-#[pyclass]
-#[derive(Parser, Debug, Clone)]
-pub struct StarCatalogArgs {
-    #[pyo3(get, set)]
-    pub source: String,
-    #[pyo3(get, set)]
-    pub center_ra: f64,
-    #[pyo3(get, set)]
-    pub center_dec: f64,
-    #[pyo3(get, set)]
-    pub fov_w: f64,
-    #[pyo3(get, set)]
-    pub fov_h: f64,
-    #[pyo3(get, set)]
-    pub roll: f64,
-    #[pyo3(get, set)]
-    pub max_magnitude: f64,
-    #[pyo3(get, set)]
-    pub lambda_nm: f64,
-    #[pyo3(get, set)]
-    pub pixel_size_m: f64,
-    #[pyo3(get, set)]
-    pub width: u32,
-    #[pyo3(get, set)]
-    pub height: u32,
-    #[pyo3(get, set)]
-    pub output: String,
-}
-
-#[pymethods]
-impl StarCatalogArgs {
-    #[new]
-    fn new(
-        source: String,
-        center_ra: f64,
-        center_dec: f64,
-        fov_w: f64,
-        fov_h: f64,
-        roll: f64,
-        max_magnitude: f64,
-        lambda_nm: f64,
-        pixel_size_m: f64,
-        width: u32,
-        height: u32,
-        output: String,
-    ) -> Self {
-        Self {
-            source,
-            center_ra,
-            center_dec,
-            fov_w,
-            fov_h,
-            roll,
-            max_magnitude,
-            lambda_nm,
-            pixel_size_m,
-            width,
-            height,
-            output,
-        }
-    }
-}
-
-pub fn process_star_catalog(args: &StarCatalogArgs) -> Result<(), Box<dyn std::error::Error>> {
-    let run_start = Instant::now();
-    let center_ra = args.center_ra.to_radians();
-    let center_dec = args.center_dec.to_radians();
-    let roll = args.roll.to_radians();
-    let fov_w = args.fov_w.to_radians();
-    let fov_h = args.fov_h.to_radians();
-
-    // 1) Rotate FOV by specified roll
-    let get_fov_start = Instant::now();
-    let center = EquatorialCoords {
-        ra: center_ra,
-        dec: center_dec,
-    };
-    let rolled_fov = fov::get_fov(center, fov_w, fov_h, roll);
-    println!("Total FOV retrieval time: {:?}", get_fov_start.elapsed());
-
-    // 2) Read stars and filter against rolled_fov to create subset of stars in view of the image
-    let read_stars_start = Instant::now();
-    let stars_in_fov = read_stars(&args.source, rolled_fov, args.max_magnitude)?;
-    println!(
-        "Total time to read and parse stars: {:?}",
-        read_stars_start.elapsed()
-    );
-
-    // 3) Render stars in FOV
-    let render_stars_start = Instant::now();
-    let img = render_stars(
-        stars_in_fov,
-        args.width,
-        args.height,
-        center,
-        fov_w,
-        fov_h,
-        roll,
-    );
-    img.save(&args.output)?;
-    println!(
-        "Total parse and write stars: {:?}",
-        render_stars_start.elapsed()
-    );
-
-    println!("Total run time elapsed: {:?}", run_start.elapsed());
-
-    Ok(())
-}
 
 #[pyfunction]
 fn process_star_catalog_py(args: StarCatalogArgs) -> PyResult<()> {
-    process_star_catalog(&args)
+    parse_and_render(&args)
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,7 @@
 use clap::Parser;
-use std::path::PathBuf;
-use std::time::Instant;
 
-use starfinder::fov::get_fov;
-use starfinder::parsing_utils::read_stars;
-use starfinder::rendering::render_stars;
-use starfinder::types::EquatorialCoords;
+use starfinder::parse_and_render::parse_and_render;
+use starfinder::types::{StarCatalogArgs};
 
 /// CLI Arguments
 #[derive(Parser, Debug)]
@@ -18,7 +14,7 @@ pub struct Args {
         value_name = "FILE",
         default_value = "data/tycho2/catalog.dat"
     )]
-    source: PathBuf,
+    source: String,
 
     /// Right Ascension of camera view center point (degrees)
     #[arg(long, default_value_t = 180.0)]
@@ -67,70 +63,21 @@ pub struct Args {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let run_start = Instant::now();
-    let args = Args::parse();
-    let center_ra = args.center_ra.to_radians();
-    let center_dec = args.center_dec.to_radians();
-    let roll = args.roll.to_radians();
-    let fov_w = args.fov_w.to_radians();
-    let fov_h = args.fov_h.to_radians();
-
-    /*println!("================ Cmd args list ===============");
-    println!("Reading stars from: {:?}", args.source);
-    println!("Center - RA (deg): {}", args.center_ra);
-    println!("Center - RA (rad): {}", center_ra);
-    println!("Center - Dec (deg): {}", args.center_dec);
-    println!("Center - Dec (rad): {}", center_dec);
-    println!("FOV width (deg): {}", args.fov_w_deg);
-    println!("FOV width (rad): {}", fov_w);
-    println!("FOV height (deg): {}", args.fov_h_deg);
-    println!("FOV height (rad): {}", fov_h);
-    println!("Roll (deg): {}", args.roll_deg);
-    println!("Roll (rad): {}", roll);
-    println!("Max magnitude: {}", args.max_magnitude);
-    println!("Lambda (wavelength) nm: {}", args.lambda_nm);
-    println!("Pixel size (meters): {}", args.pixel_size_m);
-    println!("Output image width: {}", args.width);
-    println!("Output image height: {}", args.height);
-    println!("Output image height: {}", args.height);
-    println!("Output filename: {}", args.output);
-    println!("============ End of cmd args list ============");*/
-
-    // 1) Rotate FOV by specified roll
-    let get_fov_start = Instant::now();
-    let center = EquatorialCoords {
-        ra: center_ra,
-        dec: center_dec,
+    let cmd_args = Args::parse();
+    let args = StarCatalogArgs {
+        source: cmd_args.source,
+        center_ra: cmd_args.center_ra,
+        center_dec: cmd_args.center_dec,
+        fov_w: cmd_args.fov_w,
+        fov_h: cmd_args.fov_h,
+        roll: cmd_args.roll,
+        max_magnitude: cmd_args.max_magnitude,
+        lambda_nm: cmd_args.lambda_nm,
+        pixel_size_m: cmd_args.pixel_size_m,
+        width: cmd_args.width,
+        height: cmd_args.height,
+        output: cmd_args.output,
     };
-    let rolled_fov = get_fov(center, fov_w, fov_h, roll);
-    println!("Total FOV retrieval time: {:?}", get_fov_start.elapsed());
 
-    // 2) Read stars and filter against rolled_fov to create subset of stars in view of the image
-    let read_stars_start = Instant::now();
-    let stars_in_fov = read_stars(args.source, rolled_fov, args.max_magnitude)?;
-    println!(
-        "Total time to read and parse stars: {:?}",
-        read_stars_start.elapsed()
-    );
-
-    // 4) Render stars in FOV
-    let render_stars_start = Instant::now();
-    let img = render_stars(
-        stars_in_fov,
-        args.width,
-        args.height,
-        center,
-        fov_w,
-        fov_h,
-        roll,
-    );
-    img.save(&args.output)?;
-    println!(
-        "Total parse and write stars: {:?}",
-        render_stars_start.elapsed()
-    );
-
-    println!("Total run time elapsed: {:?}", run_start.elapsed());
-
-    Ok(())
+    parse_and_render(&args)
 }

--- a/src/parse_and_render.rs
+++ b/src/parse_and_render.rs
@@ -1,0 +1,53 @@
+use std::time::Instant;
+
+use crate::fov;
+use crate::parsing_utils::read_stars;
+use crate::rendering::render_stars;
+use crate::types::{EquatorialCoords, StarCatalogArgs};
+
+pub fn parse_and_render(args: &StarCatalogArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let run_start = Instant::now();
+    let center_ra = args.center_ra.to_radians();
+    let center_dec = args.center_dec.to_radians();
+    let roll = args.roll.to_radians();
+    let fov_w = args.fov_w.to_radians();
+    let fov_h = args.fov_h.to_radians();
+
+    // 1) Rotate FOV by specified roll
+    let get_fov_start = Instant::now();
+    let center = EquatorialCoords {
+        ra: center_ra,
+        dec: center_dec,
+    };
+    let rolled_fov = fov::get_fov(center, fov_w, fov_h, roll);
+    println!("Total FOV retrieval time: {:?}", get_fov_start.elapsed());
+
+    // 2) Read stars and filter against rolled_fov to create subset of stars in view of the image
+    let read_stars_start = Instant::now();
+    let stars_in_fov = read_stars(&args.source, rolled_fov, args.max_magnitude)?;
+    println!(
+        "Total time to read and parse stars: {:?}",
+        read_stars_start.elapsed()
+    );
+
+    // 3) Render stars in FOV
+    let render_stars_start = Instant::now();
+    let img = render_stars(
+        stars_in_fov,
+        args.width,
+        args.height,
+        center,
+        fov_w,
+        fov_h,
+        roll,
+    );
+    img.save(&args.output)?;
+    println!(
+        "Total parse and write stars: {:?}",
+        render_stars_start.elapsed()
+    );
+
+    println!("Total run time elapsed: {:?}", run_start.elapsed());
+
+    Ok(())
+}

--- a/src/types/args.rs
+++ b/src/types/args.rs
@@ -1,0 +1,65 @@
+use clap::Parser;
+use pyo3::prelude::{pyclass, pymethods};
+
+#[pyclass]
+#[derive(Parser, Debug, Clone)]
+pub struct StarCatalogArgs {
+    #[pyo3(get, set)]
+    pub source: String,
+    #[pyo3(get, set)]
+    pub center_ra: f64,
+    #[pyo3(get, set)]
+    pub center_dec: f64,
+    #[pyo3(get, set)]
+    pub fov_w: f64,
+    #[pyo3(get, set)]
+    pub fov_h: f64,
+    #[pyo3(get, set)]
+    pub roll: f64,
+    #[pyo3(get, set)]
+    pub max_magnitude: f64,
+    #[pyo3(get, set)]
+    pub lambda_nm: f64,
+    #[pyo3(get, set)]
+    pub pixel_size_m: f64,
+    #[pyo3(get, set)]
+    pub width: u32,
+    #[pyo3(get, set)]
+    pub height: u32,
+    #[pyo3(get, set)]
+    pub output: String,
+}
+
+#[pymethods]
+impl StarCatalogArgs {
+    #[new]
+    fn new(
+        source: String,
+        center_ra: f64,
+        center_dec: f64,
+        fov_w: f64,
+        fov_h: f64,
+        roll: f64,
+        max_magnitude: f64,
+        lambda_nm: f64,
+        pixel_size_m: f64,
+        width: u32,
+        height: u32,
+        output: String,
+    ) -> Self {
+        Self {
+            source,
+            center_ra,
+            center_dec,
+            fov_w,
+            fov_h,
+            roll,
+            max_magnitude,
+            lambda_nm,
+            pixel_size_m,
+            width,
+            height,
+            output,
+        }
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,5 +1,7 @@
+mod args;
 mod coords;
 mod star;
 
+pub use args::*;
 pub use coords::*;
 pub use star::*;


### PR DESCRIPTION
Unify parse and render into one implementation, update lib.rs to just package the python wrapper and export modules. Move parser/renderer to its own lib file, and have main.rs call this as well resulting in a single implementation between python and rust on the CLI